### PR TITLE
Updated to build on recent systems (macOS 10.15.7 and Ubuntu 20.04.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dumpOSC/dumpOSC
+sendOSC/sendOSC
+*.o
+*.a

--- a/dumpOSC/README.md
+++ b/dumpOSC/README.md
@@ -1,0 +1,172 @@
+## The "dumpOSC" Program
+
+Matt Wright, 2/3/98. Updated 3/3/03
+
+The program "dumpOSC" listens on a UDP or Unix port for messages in
+the [OpenSound Control](index.html) network format, and prints their
+contents to the screen as they are received. This is useful primarily
+for debugging OpenSound Control clients.
+
+### Availability
+
+The "dumpOSC" program is available as [source code](/OSC/src/dumpOSC/)
+and as [compiled binaries for Mac OS X](/OSC/send%2BdumpOSC-OSX.tar.gz).
+It has been tested under Linux, Mac OS X, and SGI IRIX.
+
+### Invoking dumpOSC
+
+The command-line argument to dumpOSC is the port number (UDP or Unix) to
+which dumpOSC should listen. For example, the following invocation
+causes dumpOSC to listen to port 7123:
+
+`dumpOSC 7123`
+
+You can also invoke dumpOSC with the -showbytes flag, which must come
+after the port number. [See below](#showbytes) for what this does.
+
+### Interpreting dumpOSC's output
+
+The output of dumpOSC is the inverse of the input to
+[sendOSC](clients/sendOSC.html). Here is some sample text that dumpOSC
+might print:
+
+    [ 1
+    /voices/0/tm/rate 0.900000
+    /voices/3/tpe/tpe_points -4.000000 15.000000 4.000000 8.120000 10.000000 5.000000
+    /tplibrary/load "foo.fmt"
+    ]
+    [ 1
+    /voices/0/tm/goto 0.560000
+    ]
+
+The square brackets delimit the messages that were received in the same
+packet, grouped by the OpenSound Control "#bundle" mechanism. In the
+above example, the two pairs of square brackets indicate that two
+packets were received, the first containing three messages and the
+second containing only one. After the open square bracket comes the time
+tag associated with the bundle, printed in hexadecimal. Both of these
+bundles have a time tag of 1, meaning "do it immediately".
+
+dumpOSC prints each message on its own line, starting with the message
+address and name and continuing with all of the arguments to the
+message.
+
+In the above example, the first message received was
+"/voices/0/tm/rate", with a single floating point argument 0.9. The
+second message received was "/voices/3/tpe/tpe_points", with six
+floating point arguments. The third message, "/tplibrary/load", had a
+single string argument. String arguments are always delimited by
+double-quote characters.
+
+Packets that are not bundles (i.e., packets that consist of a single
+message) are printed on a single line, with no brackets. Nested bundles
+are printed with nested brackets.
+
+### Message Argument Type-guessing Heuristics
+
+The OpenSound Control format now includes type tags that indicate how to
+interpret each of the arguments as a floating point number, string,
+integer, etc. The dumpOSC program reads these type tags and correctly
+interprets argument types.
+
+Early implementations of OpenSound Control allowed messages that did not
+contain type tags. The idea was that the sender of a message had to know
+which messages required which argument types, and the receiving
+application just coerced the binary argument data to the expected types.
+This caused lots of problems and is strongly discouraged.
+
+Nevertheless, dumpOSC can receive non-type-tagged messages; when this
+happens it uses the following heuristics to "guess" what the types of
+the arguments were supposed to be:
+
+1) If a given argument word represents an integer between -1000 and
+1000000 (inclusive), it's interpreted (i.e., printed) as an integer.
+
+2) Otherwise, if a given argument word represents a floating point
+number between -1000.0f and 0.f or between 0.000001f and 1000000.0f,
+it's interpreted as a float. (Note that all of the integers from 0 to
+1000000000 represent floating point numbers between 0. and 0.005, so any
+reasonably small nonnegative integer value will also appear to be a very
+small floating point value. Also, the first four characters of strings
+like "/usr" and "/home" have bit representations that look like very
+small positive floating point numbers.)
+
+3) Otherwise, if a given argument word is the beginning of a valid
+OpenSound Control-formatted string, all of the bytes of that string are
+interpreted as a string. A valid string is a sequence of characters that
+satisfy the isprint() test (from ctype.h) ending with a null character
+and enough extra null characters to align the string on a 4-byte
+boundary.
+
+4) As a last resort, if a given argument word satisfies none of these
+criteria, it's printed in hex, followed by a question mark, e.g.,
+"0xDE23C860(?)".
+
+Obviously, these heuristics are just heuristics. Floats between 0. and
+0.00001 will be interpreted as integers or strings. The string "@"
+will be interpreted as the floating point number 2.000. But for most
+reasonable data, these heuristics work fine.
+
+### []{#showbytes}The -showbytes Option
+
+The -showbytes option to dumpOSC (which can appear on the command line
+after the port number) runs dumpOSC in a very verbose mode where it
+prints every single byte of every message it receives. This is mainly
+useful for low-level debugging of clients when you fear that they
+aren't even generating legal OpenSound Control packets.
+
+Here's how dumpOSC would print the first of the above two packets if
+you invoked it with the -showbytes flag:
+
+    128 byte message:
+     23 (#)  62 (b)  75 (u)  6e (n)
+     64 (d)  6c (l)  65 (e)  0 ()
+     0 ()    0 ()    0 ()    0 ()
+     0 ()    0 ()    0 ()    1 ()
+     0 ()    0 ()    0 ()    18 ()
+     2f (/)  76 (v)  6f (o)  69 (i)
+     63 (c)  65 (e)  73 (s)  2f (/)
+     30 (0)  2f (/)  74 (t)  6d (m)
+     2f (/)  72 (r)  61 (a)  74 (t)
+     65 (e)  0 ()    0 ()    0 ()
+     3f (?)  66 (f)  66 (f)  66 (f)
+     0 ()    0 ()    0 ()    34 (4)
+     2f (/)  76 (v)  6f (o)  69 (i)
+     63 (c)  65 (e)  73 (s)  2f (/)
+     33 (3)  2f (/)  74 (t)  70 (p)
+     65 (e)  2f (/)  74 (t)  70 (p)
+     65 (e)  5f (_)  70 (p)  6f (o)
+     69 (i)  6e (n)  74 (t)  73 (s)
+     0 ()    0 ()    0 ()    0 ()
+     c0 (¿)  80 ()   0 ()    0 ()
+     41 (A)  70 (p)  0 ()    0 ()
+     40 (@)  80 ()   0 ()    0 ()
+     41 (A)  1 ()    eb (Î)  85 (
+    )
+     41 (A)  20 ( )  0 ()    0 ()
+     40 (@)  a0 (Ý)  0 ()    0 ()
+     0 ()    0 ()    0 ()    18 ()
+     2f (/)  74 (t)  70 (p)  6c (l)
+     69 (i)  62 (b)  72 (r)  61 (a)
+     72 (r)  79 (y)  2f (/)  6c (l)
+     6f (o)  61 (a)  64 (d)  0 ()
+     66 (f)  6f (o)  6f (o)  2e (.)
+     66 (f)  6d (m)  74 (t)  0 ()
+
+    [ 1
+    /voices/0/tm/rate 0.900000
+    /voices/3/tpe/tpe_points -4.000000 15.000000 4.000000 8.120000 10.000000 5.00000
+    0
+    /tplibrary/load "foo.fmt"
+    ]
+
+As you can see, dumpOSC prints the byte-by-byte dump first, and then
+prints the packet in the usual way. The byte-by-byte dump prints four
+bytes on each line, giving each byte's value in hex, and then printing
+the byte as anASCII character in parentheses.
+
+<hr/>
+
+The text above was translated from the HTML retrieved on 2021-06-11:
+
+<http://cnmat.org/OpenSoundControl/dumpOSC.html>

--- a/dumpOSC/dumpOSC.c
+++ b/dumpOSC/dumpOSC.c
@@ -427,7 +427,7 @@ printf("polldev %d\n", polldevs[j].fd);
 		        r = select(nfds, &read_fds, &write_fds, (fd_set *)0, 
 		                        (struct timeval *)0);
 		        if (r < 0)  /* select reported an error */
-			  return;
+			  return 1;
 		        {
 			    int j;
 			    
@@ -444,7 +444,7 @@ printf("polldev %d\n", polldevs[j].fd);
 				  /* printf("received UDP packet of length %d\n",  n); */
 				  r = Synthmessage(mbuf, n, &cl_addr, clilen, sockfd) ;
 
-				  if( sgi_HaveToQuit()) return;
+				  if( sgi_HaveToQuit()) return 2;
 				  if(r>0) goto back;
 				  clilen = maxclilen;
 				}
@@ -459,7 +459,7 @@ printf("polldev %d\n", polldevs[j].fd);
 
 				  r=Synthmessage(mbuf, n, &ucl_addr, uclilen,usockfd) ;
 
-				  if( sgi_HaveToQuit()) return;
+				  if( sgi_HaveToQuit()) return 3;
 				  if(r>0) goto back;
 				  uclilen = umaxclilen;
 				}

--- a/dumpOSC/dumpOSC.c
+++ b/dumpOSC/dumpOSC.c
@@ -358,7 +358,7 @@ int main(int argc, char **argv) {
 	    exit(2);
 	  }
 	} else {
-	  n = recvfrom(0, mbuf, MAXMESG, 0, &cl_addr, &clilen);
+	  n = recvfrom(0, mbuf, MAXMESG, 0, (struct sockaddr *)&cl_addr, (socklen_t*)&clilen);
 	  if(n>0) {
 	      sockfd = 0;
 	      udp_port = -1;
@@ -434,7 +434,7 @@ printf("polldev %d\n", polldevs[j].fd);
 		        if(FD_ISSET(sockfd, &read_fds))
 			{
 				clilen = maxclilen;
-				while( (n = recvfrom(sockfd, mbuf, MAXMESG, 0, &cl_addr, &clilen)) >0) 
+				while( (n = recvfrom(sockfd, mbuf, MAXMESG, 0, (struct sockaddr*)&cl_addr, (socklen_t*)&clilen)) >0) 
 				{
 				  int r;
 				  /* printf("received UDP packet of length %d\n",  n); */
@@ -448,7 +448,7 @@ printf("polldev %d\n", polldevs[j].fd);
 		        if(FD_ISSET(usockfd, &read_fds))
 			{
 				uclilen = umaxclilen;
-				while( (n = recvfrom(usockfd, mbuf, MAXMESG, 0, &ucl_addr, &uclilen)) >0) 
+				while( (n = recvfrom(usockfd, mbuf, MAXMESG, 0, (struct sockaddr *)&ucl_addr, (socklen_t*)&uclilen)) >0) 
 				{
 				  int r;
 				  /* printf("received UNIX packet of length %d\n",  n); */

--- a/dumpOSC/dumpOSC.c
+++ b/dumpOSC/dumpOSC.c
@@ -281,7 +281,7 @@ void PrintClientAddr(ClientAddr CA) {
     printf("  clilen %d, sockfd %d\n", CA->clilen, CA->sockfd);
     printf("  sin_family %d, sin_port %d\n", CA->cl_addr.sin_family,
 	   CA->cl_addr.sin_port);
-    printf("  address: (%x) %s\n", addr,  inet_ntoa(CA->cl_addr.sin_addr));
+    printf("  address: (%lx) %s\n", addr,  inet_ntoa(CA->cl_addr.sin_addr));
 
     printf("  sin_zero = \"%c%c%c%c%c%c%c%c\"\n", 
 	   CA->cl_addr.sin_zero[0],

--- a/dumpOSC/dumpOSC.c
+++ b/dumpOSC/dumpOSC.c
@@ -400,11 +400,7 @@ printf("polldev %d\n", polldevs[j].fd);
 		caught_sigint = 0;
 
 		/* Set signal handler */
-#ifdef OSX
 		signal(SIGINT, catch_sigint);
-#else
-   		sigset(SIGINT, catch_sigint);
-#endif
 	
 		while(!caught_sigint)
 		{

--- a/dumpOSC/printOSCpacket.c
+++ b/dumpOSC/printOSCpacket.c
@@ -8,6 +8,9 @@ extern void complain(char *s, ...);
 #endif
 
 #include <stdio.h>
+#include <string.h> // strncmp
+#include <ctype.h> // isprint
+
 #include "printOSCpacket.h"
 
 void PrintOSCPacketRecursive(char *buf, int n, int bundleDepth);

--- a/dumpOSC/printOSCpacket.c
+++ b/dumpOSC/printOSCpacket.c
@@ -10,6 +10,7 @@ extern void complain(char *s, ...);
 #include <stdio.h>
 #include <string.h> // strncmp
 #include <ctype.h> // isprint
+#include <stdint.h> // uint32_t
 
 #include "printOSCpacket.h"
 
@@ -59,9 +60,9 @@ void PrintOSCPacketRecursive(char *buf, int n, int bundleDepth) {
 	}
 
 	/* Print the time tag */
-	PRINTF("%s[ %lx%08lx\n", indentation,
-	       ntohl(*((unsigned long *)(buf+8))),
-	       ntohl(*((unsigned long *)(buf+12))));
+	PRINTF("%s[ %x%08x\n", indentation,
+	       ntohl(*((uint32_t*)(buf+8))),
+	       ntohl(*((uint32_t*)(buf+12))));
 	/* Note: if we wanted to actually use the time tag as a little-endian
 	   64-bit int, we'd have to word-swap the two 32-bit halves of it */
 

--- a/dumpOSC/printOSCpacket.c
+++ b/dumpOSC/printOSCpacket.c
@@ -11,6 +11,7 @@ extern void complain(char *s, ...);
 #include <string.h> // strncmp
 #include <ctype.h> // isprint
 #include <stdint.h> // uint32_t
+#include <arpa/inet.h> // ntohl
 
 #include "printOSCpacket.h"
 

--- a/libOSC/OSC-client.c
+++ b/libOSC/OSC-client.c
@@ -58,6 +58,8 @@ Windows Max/MSP externals with GCC!
 #include <winsock2.h>
 #endif
 
+#include <arpa/inet.h> // htonl
+
 char *OSC_errorMessage;
 
 static int my_strlen(char *s);

--- a/sendOSC/README.md
+++ b/sendOSC/README.md
@@ -1,0 +1,201 @@
+## The "sendOSC" Program
+
+Matt Wright, revised 3/3/3
+
+The program "sendOSC" is a text-based [OpenSoundControl](index.html)
+client. User can enter messages via command line arguments or standard
+input; sendOSC formats these messages according to the
+"OpenSoundControl" protocol, then sends the OpenSoundControl packet to
+an OpenSoundControl server via UDP or Unix protocol.
+
+### Availability
+
+The "sendOSC" program is available as [source code](/OSC/src/sendOSC)
+and as [compiled binaries for Mac OS X](/OSC/send%2BdumpOSC-OSX.tar.gz).
+It has been tested under Linux, Mac OS X, and SGI IRIX.
+
+### Selecting a host machine and port number
+
+    usage: sendOSC [-h host] [-r] port_number [message...]
+
+The "-h" flag indicates that the next argument is the name of the
+target host. The "-r" flag instructs sendOSC to look at the
+environment variable REMOTE_ADDR to get the name of the target host. The
+host can be either an Internet host name (e.g., "les") or an Internet
+address in standard dot notation (e.g., "128.32.122.13")
+
+If a target host is given, sendOSC uses the UDP protocol. Otherwise, the
+program uses the Unix protocol to connect to an OpenSoundControl server
+on the same machine.
+
+The next command argument must be the port number.
+
+For example, this invocation of sendOSC causes it to try to connect to
+host "rodet" on port 7009:
+
+`sendOSC -h rodet 7009 `
+
+This invocation asks sendOSC to connect to port 7005 using the UNIX
+protocol:
+
+`sendOSC 7005 `
+
+This invocation asks sendOSC to connect to port 7022 of host
+128.32.122.14:
+
+`setenv REMOTE_ADDR 128.32.122.14 sendOSC -r 7022`
+
+### Command-Line Mode
+
+If there are any additional command-line arguments after the port
+number, they're taken to be messages to be sent. In this mode, sendOSC
+reads all of the command line arguments, translates them into a
+OpenSoundControl packet, sends it in a single packet, and exits. sendOSC
+does not print any error or warning messages in this mode, which makes
+it a useful helper program for, e.g., CGI scripts.
+
+Each command-line argument after the port number corresponds to an
+entire OpenSoundControl message, according to this comma-delimited
+format:
+
+`message_name,arg1,arg2,arg3,arg4,... `
+
+Each argument must be one of the following:
+
+-   `integer: [-]?[0-9]+`
+-   `float: [-]?([0-9]+.[0-9]*|.[0-9]+)`
+-   `string: any other sequence of non-comma characters   `
+
+The messages are combined into a single UDP packet and sent atomically.
+
+Example: The following Unix command sends the messages
+"/voices/0/tp/timbre_index 0", "/voices/0/tm/rate 1.0", and
+"/voices/0/tm/goto 0.0" to a server on port 7003 of the current
+machine:
+
+`sendOSC 7003 /voices/0/tp/timbre_index,0 /voices/0/tm/rate,1.0 /voices/0/tm/goto,0.0`
+
+Example: The following Unix command sends the messages
+"/voices/1/tp/timbre_index 3" and "load_file
+/usr/local/near/data/foo.format":
+
+`sendOSC 7003 /voices/1/tp/timbre_index,3 load_file,/usr/local/near/data/foo.format`
+
+Example: The following Unix command sends the message
+"/voices/2/tp/tone_bank 200. -19. 300. -32. 400. -40.":
+
+`sendOSC 7003 /voices/2/tp/tone_bank,200.,-19.,300.,-32.,400.,-40.`
+
+Remember that the Unix shell will interpret any whitespace characters
+(space, tab, etc.) as delimiting the arguments to sendOSC. So if you
+want your string arguments to include any space characters, you must
+quote them to the shell. For example, these equivalent commands send the
+message "string_message" with the argument string "this string has
+spaces":
+
+`sendOSC 7003 "string_message,this string has spaces" sendOSC 7003 string_message,this\ string\ has\ spaces`
+
+There are other characters which are special to Unix shells: "!",
+"\$", ";", "\~", etc. Be careful.
+
+### Interactive Mode
+
+If the port number is the last command-line argument, sendOSC enters an
+interactive mode. In this mode, lines of stdin should look like this:
+
+`message_name arg1 arg2 arg3... `
+
+Each line of stdin is converted into a one-message OpenSoundControl
+packet and sent immediately.
+
+Example:
+
+`sendOSC 7003 message1 2.0 3.14159 message2 100 200 300 message3 string1 string_number_two /the/third/string message4 1 2.0 three`
+
+In this interactive mode, any whitespace character is interpreted as
+delimiting the arguments to a message. To include whitespace in a
+string, surround the entire string with double-quote characters.
+Example:
+
+`sendOSC 7003 stringmessage "This string has spaces in it"`\
+To exit interactive mode and return to the shell, type an EOF
+(control-D) or interrupt (control-C). The sendOSC program will also quit
+if it is unable to send a packet, i.e., if you don't have a server
+listening on the machine and port that sendOSC is trying to send to.
+
+#### Constructing Multiple-Message Bundles
+
+To bundle multiple messages into the same packet while in interactive
+mode, begin by entering an open bracket character ("[") by itself on
+a line. Once you've done this, all of the lines you enter will be
+accumulated into a large OpenSoundControl bundle until you enter a close
+bracket character ("]") by itself on a line, at which point the
+entire packet will be sent.
+
+Example:
+
+`sendOSC 7003 [ /voices/0/tp/timbre_index 7.0 /voices/0/tm/rate 1.0 /voices/0/tm/goto 0.0 ]`
+
+These bracketed bundles can be nested.
+
+#### Blank Lines
+
+If you enter a blank line in the middle of constructing a message group
+with [ and ], it is ignored. Otherwise, if you enter a blank line,
+sendOSC re-sends the previous packet, which may be a single message or a
+group of messages.
+
+#### The "play" Hack
+
+To save typing, if you enter "play" by itself on an empty line, it's
+equivalent to the following:
+
+    [
+    /voices/0/tp/timbre_index 0
+    /voices/0/tm/goto 0.0
+    ]
+
+#### Sending Time Tags
+
+The OpenSound Control protocol includes space for a 8-byte time tag in
+each bundle. By default, sendOSC uses the value 1, meaning "do it
+immediately" as the time tag for every bundle. But you can put a time
+tag into a bundle by typing some stuff after the open bracket character
+that opens the bundle. There are two ways to do this.
+
+If you have a hexadecimal number after the open bracket character, it
+will be used as the time tag. Since OSC time tags are 8 bytes, you can
+have up to 16 hex digits.
+
+If you have a plus sign and then a (decimal) number after the open
+bracket character, the number will be interpreted as a number of seconds
+into the future, which will be added to the computer's notion of the
+current time to produce the time tag. (This feature is currently
+available only on the SGI version of sendOSC.)
+
+### Exit Status Codes
+
+sendOSC sets the Unix exit status to indicate whether or not it was
+successful. In interactive mode, sendOSC also prints warning and error
+messages to the screen, so the exit status is not so crucial. In command
+line mode, however, the exit status is the only way to know if sendOSC
+could do its job.
+
+Here are the possible exit status codes:
+
+0: Successful
+
+2: Message(s) were dropped because of buffer overflow.
+
+3: Socket error
+
+4: Usage error: incorrect command-line arguments, or a "-r" without
+REMOTE_ADDR defined.
+
+5: Internal error: this should never occur.
+
+<hr/>
+
+The text above was translated from the HTML retrieved on 2021-06-11:
+
+<http://cnmat.org/OpenSoundControl/clients/sendOSC.html>

--- a/sendOSC/htmsocket.c
+++ b/sendOSC/htmsocket.c
@@ -61,6 +61,9 @@ The OSC webpage is http://cnmat.cnmat.berkeley.edu/OpenSoundControl
 
 #include <stdlib.h>
 
+#include <string.h> // strlen, strcpy
+#include <strings.h> // bzero
+
 #define UNIXDG_PATH "/tmp/htm"
 #define UNIXDG_TMP "/tmp/htm.XXXXXX"
 #include "htmsocket.h"                          

--- a/sendOSC/sendOSC.c
+++ b/sendOSC/sendOSC.c
@@ -305,7 +305,7 @@ OSCTimeTag ParseTimeTag(char *s) {
     if (isdigit(*p) || (*p >= 'a' && *p <='f') || (*p >= 'A' && *p <='F')) {
 	/* They specified the 8-byte tag in hex */
 	OSCTimeTag tt;
-	if (sscanf(p, "%llx", &tt) != 1) {
+	if (sscanf(p, "%llx", (uint64_t*)&tt) != 1) {
 	    complain("warning: couldn't parse time tag %s\n", s);
 	    return OSCTT_Immediately();
 	}

--- a/sendOSC/sendOSC.c
+++ b/sendOSC/sendOSC.c
@@ -93,7 +93,7 @@ static int exitStatus = 0;
 
 static int useTypeTags = 1;
 
-main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
     int portnumber;
     char *hostname = 0;
     void *htmsocket;

--- a/sendOSC/sendOSC.c
+++ b/sendOSC/sendOSC.c
@@ -54,6 +54,7 @@ compiling:
 #include <stdlib.h>
 /* #include <bstring.h> */
 #include <string.h>
+#include <ctype.h> // isdigit, isspace
 
 
 typedef struct {

--- a/sendOSC/sendOSC.c
+++ b/sendOSC/sendOSC.c
@@ -450,7 +450,7 @@ typedArg ParseToken(char *token) {
 	next = 0;
 	printf("before: curr %p, next %p\n", curr, next);
 	l = strtol(curr, &next, 0);
-	printf("after: curr %p, next %p, l %d\n", curr, next, l);	
+	printf("after: curr %p, next %p, l %ld\n", curr, next, l);	
 	if (curr == next) {
 	  fatal_error("Ungerminated blob\n");
 	}

--- a/sendOSC/sendOSC.c
+++ b/sendOSC/sendOSC.c
@@ -55,7 +55,7 @@ compiling:
 /* #include <bstring.h> */
 #include <string.h>
 #include <ctype.h> // isdigit, isspace
-
+#include <arpa/inet.h> // ntohl
 
 typedef struct {
     enum {INT, FLOAT, STRING, BLOB} type;


### PR DESCRIPTION
I changed as little code as possible to make `sendOSC` and `dumpOSC` build without errors or warnings on recent systems. Errors on macOS 10.15.7 and Ubuntu 20.04.2 prevented me from using either tool. I also added `README.md` for both tools based on the HTML documentation found on the CNMAT site.
